### PR TITLE
Ignoring package-lock.json for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ local.properties
 #
 node_modules/
 npm-debug.log
+
+# package-lock.json
+# https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json
+package-lock.json


### PR DESCRIPTION
Also locking down our versions a little more. [ch4884]

Further (optional) reading:
https://docs.npmjs.com/files/package-lock.json
https://docs.npmjs.com/files/package-locks
npm/npm#17979
npm/npm#18103

TL;DR: There is much community debate about this file.
